### PR TITLE
Fix PHP notice on apply_fiters("the_content")

### DIFF
--- a/public/class-cortex-public.php
+++ b/public/class-cortex-public.php
@@ -111,7 +111,7 @@ class Cortex_Public {
 
 		global $post;
 
-		if (self::$rendering) {
+		if (self::$rendering || empty($post)) {
 			return $content;
 		}
 


### PR DESCRIPTION
Prevent PHP Notice bug on using apply_filters("the_content") in a taxonomy page, or any other page that does not contain a post.